### PR TITLE
Alterado caracter de separacao da string de conexao. Antes era um car…

### DIFF
--- a/EixoX.RocketLauncher/EixoX.RocketLauncher.ConsoleApp/settings.eixox
+++ b/EixoX.RocketLauncher/EixoX.RocketLauncher.ConsoleApp/settings.eixox
@@ -1,0 +1,1 @@
+DefaultConnectionString>Data source=10.0.0.35;Initial Catalog=PhidelisUVV;User Id=usuariosga;Password=senha

--- a/EixoX.RocketLauncher/EixoX.RocketLauncher/Command/SettingsBasedCommand.cs
+++ b/EixoX.RocketLauncher/EixoX.RocketLauncher/Command/SettingsBasedCommand.cs
@@ -29,7 +29,7 @@ namespace EixoX.RocketLauncher
 
                     foreach (string setting in settings)
                     {
-                        string[] kvp = setting.Split('=');
+                        string[] kvp = setting.Split('>');
                         if (kvp.Length == 2)
                             if (!KeyValueSettings.ContainsKey(kvp[0]))
                             {


### PR DESCRIPTION
…acter =, que causava um erro, pois a string de conexao tambem possui o mesmo caracter. alterado para > .
